### PR TITLE
update git version in gemspec

### DIFF
--- a/generamba.gemspec
+++ b/generamba.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'thor', '0.19.1'
   spec.add_runtime_dependency 'xcodeproj', '>= 1.5.0', '< 2.0.0'
   spec.add_runtime_dependency 'liquid', '4.0.0'
-  spec.add_runtime_dependency 'git', '1.2.9.1'
+  spec.add_runtime_dependency 'git', '~> 1.7'
   spec.add_runtime_dependency 'cocoapods-core', '>= 1.4.0', '< 2.0.0'
   spec.add_runtime_dependency 'terminal-table', '1.4.5'
 


### PR DESCRIPTION
Resolving conflict

```
Bundler could not find compatible versions for gem "git":
  In Gemfile:
    danger (~> 8.4.2) x86_64-darwin-19 was resolved to 8.4.2, which depends on
      git (~> 1.7) x86_64-darwin-19

    generamba x86_64-darwin-19 was resolved to 1.4.1, which depends on
      git (= 1.2.9.1) x86_64-darwin-19
```

Now we can update danger to latest available version.

Tested on standart template for screens.